### PR TITLE
Fix trade_client IndentationError

### DIFF
--- a/trade_client.py
+++ b/trade_client.py
@@ -7,37 +7,37 @@ def get_price(coin):
 
 
 def convert_volume(coin, quantity, last_price):
-        """Converts the volume given in QUANTITY from USDT to the each coin's volume"""
+    """Converts the volume given in QUANTITY from USDT to the each coin's volume"""
 
-        try:
-            info = client.get_symbol_info(coin)
-            step_size = info['filters'][2]['stepSize']
-            lot_size = {coin:step_size.index('1') - 1}
+    try:
+        info = client.get_symbol_info(coin)
+        step_size = info['filters'][2]['stepSize']
+        lot_size = {coin:step_size.index('1') - 1}
 
-            if lot_size[coin] < 0:
-                lot_size[coin] = 0
+        if lot_size[coin] < 0:
+            lot_size[coin] = 0
 
-        except:
-            print("Ran except block for lot size")
-            lot_size = {coin:0}
-            pass
+    except:
+        print("Ran except block for lot size")
+        lot_size = {coin:0}
+        pass
 
-        print(lot_size[coin])
-        # calculate the volume in coin from QUANTITY in USDT (default)
-        volume = float(quantity / float(last_price))
+    print(lot_size[coin])
+    # calculate the volume in coin from QUANTITY in USDT (default)
+    volume = float(quantity / float(last_price))
 
-        # define the volume with the correct step size
-        if coin not in lot_size:
-            volume = float('{:.1f}'.format(volume))
+    # define the volume with the correct step size
+    if coin not in lot_size:
+        volume = float('{:.1f}'.format(volume))
 
+    else:
+        # if lot size has 0 decimal points, make the volume an integer
+        if lot_size[coin] == 0:
+            volume = int(volume)
         else:
-            # if lot size has 0 decimal points, make the volume an integer
-            if lot_size[coin] == 0:
-                volume = int(volume)
-            else:
-                volume = float('{:.{}f}'.format(volume, lot_size[coin]))
+            volume = float('{:.{}f}'.format(volume, lot_size[coin]))
 
-        return volume
+    return volume
 
 
 def create_order(coin, amount, action):


### PR DESCRIPTION
Remove an indentation level from the `convert_volume` function in `trade_client.py` to fix an `IndentationError`.