### PR TITLE
Support TLDs other than com

### DIFF
--- a/auth/auth.example.yml
+++ b/auth/auth.example.yml
@@ -2,3 +2,4 @@
   # CLIENT DETAILS
   binance_api: "BINANCE_API_KEY"
   binance_secret: "BINANCE_SECRET"
+  binance_tld: "BINANCE_TLD"

--- a/auth/binance_auth.py
+++ b/auth/binance_auth.py
@@ -8,4 +8,4 @@ def load_binance_creds(file):
     with open(file) as file:
         auth = yaml.load(file, Loader=yaml.FullLoader)
 
-    return Client(api_key=auth['binance_api'], api_secret=auth['binance_secret'], tld=auth['binance_tld'])
+    return Client(api_key = auth['binance_api'], api_secret = auth['binance_secret'], tld = "com" if 'binance_tld' not in auth else auth['binance_tld'])

--- a/auth/binance_auth.py
+++ b/auth/binance_auth.py
@@ -8,4 +8,4 @@ def load_binance_creds(file):
     with open(file) as file:
         auth = yaml.load(file, Loader=yaml.FullLoader)
 
-    return Client(auth['binance_api'], auth['binance_secret'])
+    return Client(api_key=auth['binance_api'], api_secret=auth['binance_secret'], tld=auth['binance_tld'])


### PR DESCRIPTION
Adding config entry for binance_tld to support TLDs other than com, such as us for binance.us.