### PR TITLE
Added a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:alpine3.14	
+
+RUN apk add --no-cache git build-base && \
+    git clone https://github.com/CyberPunkMetalHead/binance-trading-bot-new-coins /app && \
+    pip3 install python-binance pyaml
+	
+WORKDIR app	
+	
+CMD ["python3", "main.py"]


### PR DESCRIPTION
Now binance-trading-bot-new-coins can be used as a docker image.

Docker CLI:
```
docker run -i -v /localfolder/auth.yml:/app/auth/auth.env -v /localfolder/config.yml:/app/config.yml yourimagename:latest
```